### PR TITLE
Removing Call to Deprecated vte_set_background_transparent()

### DIFF
--- a/rigo/rigo/ui/gtk3/widgets/terminal.py
+++ b/rigo/rigo/ui/gtk3/widgets/terminal.py
@@ -174,7 +174,6 @@ class TerminalWidget(Vte.Terminal):
         self.set_color_bold_rgba(fg_rgba)
 
     def _configure(self):
-        self.set_background_transparent(False)
         self.set_emulation("xterm")
         self.set_font_from_string("Monospace 9")
         self.set_scrollback_lines(10000)


### PR DESCRIPTION
For some reason this has recently been causing rigo not to start
in my system, but the fact that it is already deprecated should
be enough to just get rid of it.
