### PR TITLE
Update package-hashes to default to sha256 gpg

### DIFF
--- a/conf/client.conf
+++ b/conf/client.conf
@@ -56,7 +56,7 @@ files-backup = false
 # Default parameter if unset: sha1 sha256 sha512 gpg
 # PLEASE NOTE: to fully disable GPG feature, please have a look at the
 # "gpg" option below.
-package-hashes = sha1 gpg
+package-hashes = sha256 gpg
 
 # GnuPG repository and packages verification feature.
 # Valid parameters: disable, enable, true, false, disabled, enabled, 0, 1


### PR DESCRIPTION
Please see: https://konklone.com/post/why-google-is-hurrying-the-web-to-kill-sha-1

> Walker's estimate suggested then that a SHA-1 collision would cost $2M in 2012, $700K in 2015, $173K in 2018, and $43K in 2021. Based on these numbers, Schneier suggested that an "organized crime syndicate" would be able to forge a certificate in 2018, and that a university could do it in 2021.
