### PR TITLE
[entropy.tools] add PPC to elf_class_strtoint

### DIFF
--- a/lib/entropy/tools.py
+++ b/lib/entropy/tools.py
@@ -2610,9 +2610,9 @@ def elf_class_strtoint(elf_class_str):
     @return: ELF class int value
     @rtype: int
     """
-    if elf_class_str in ("X86_64", "ELFCLASS64", "PARISC", "SPARCV9", "AARCH64"):
+    if elf_class_str in ("X86_64", "ELFCLASS64", "PARISC", "SPARCV9", "AARCH64", "PPC64"):
         return 2
-    elif elf_class_str in ("ARM", "386", "ELFCLASS32", "SPARC", "MIPS"):
+    elif elf_class_str in ("ARM", "386", "ELFCLASS32", "SPARC", "MIPS", "PPC"):
         return 1
     else:
         raise ValueError('unsupported %s' % (elf_class_str,))


### PR DESCRIPTION
Without this, entropy crashes when running `equo rescue spmsync` on a system containing PPC files with the following error:
```
╠  @@ These packages were added:
╠     # dev-util/jprofiler-9.0
Continue ? [Yes/No] yes
╠  +++  (1/1) dev-util/jprofiler-9.0
Traceback (most recent call last):
  File "/usr/lib/entropy/client/solo/commands/rescue.py", line 740, in _spmsync
    data = spm.extract_package_metadata(tmp_path)
  File "/usr/lib/entropy/lib/entropy/spm/plugins/interfaces/portage_plugin/__init__.py", line 1567, in extract_package_metadata
    needed_elf_file)
  File "/usr/lib/entropy/lib/entropy/spm/plugins/interfaces/portage_plugin/__init__.py", line 4733, in _extract_pkg_metadata_needed_libs_elf_2
    elfclass = entropy.tools.elf_class_strtoint(elfclass_str)
  File "/usr/lib/entropy/lib/entropy/tools.py", line 2618, in elf_class_strtoint
    raise ValueError('unsupported %s' % (elf_class_str,))
ValueError: unsupported PPC
☛  @@ dev-haskell/djinn-ghc-0.0.2.3, Metadata generation error: unsupported PPC
╠  @@ Update complete
```
Note that this is not limited to PPC systems - the dev-util/jprofiler ebuild from fw-overlay installs some shared libraries in /opt for all supported architectures, without regard to the current arch. (This is arguably the fault of a poorly written ebuild.)