### PR TITLE
[entropy.core] _system_parser: Actually read the file

### DIFF
--- a/lib/entropy/core/settings/base.py
+++ b/lib/entropy/core/settings/base.py
@@ -1611,7 +1611,7 @@ class SystemSettings(Singleton, EntropyPluginStore):
             'spm_backend': None,
         }
 
-        if const_file_readable(etp_conf):
+        if not const_file_readable(etp_conf):
             return data
 
         const_secure_config_file(etp_conf)


### PR DESCRIPTION
Fixed bug introduced in: a2315b1 [entropy.core] _system_parser: drop access() usage

This ensures that /etc/entropy/entropy.conf is used when it exists and is readable, instead of being ignored.