### PR TITLE
[entropy.client] fixes to exception handler

### DIFF
--- a/client/solo/main.py
+++ b/client/solo/main.py
@@ -55,8 +55,8 @@ def handle_exception(exc_class, exc_instance, exc_tb):
     if exc_class is SystemExit:
         return
 
-    if exc_class is IOError:
-        if exc_instance.errno != errno.EPIPE:
+    if issubclass(exc_class, IOError): # in Python 3.3+ it's BrokenPipeError
+        if exc_instance.errno == errno.EPIPE:
             return
 
     if exc_class is KeyboardInterrupt:
@@ -70,7 +70,7 @@ def handle_exception(exc_class, exc_instance, exc_tb):
         entropy.tools.print_exception(tb_data = exc_tb)
         pdb.set_trace()
 
-    if exc_class is OSError:
+    if exc_class in (IOError, OSError):
         if exc_instance.errno == errno.ENOSPC:
             print_generic(t_back)
             _text.output(


### PR DESCRIPTION
- correct negated logic in EPIPE hanling
- correct ENOSPC handling (it's IOError, but OSError was catched)
- support Python 3.3+ which got reworked exceptions

The first point is the most important. Now unhandled IOExceptions will not be dropped silently. Here is an example on what will be present on console after this change when tried to install a pkgfile as non-root (thanks to fakeroot):

...
Traceback (most recent call last):
  File "../lib/entropy/tools.py", line 1546, in dump_entropy_metadata
    with open(entropy_package_file, "r+b") as old:
IOError: [Errno 13] Permission denied: u'/var/tmp/entropy/net-misc/net-misc:(...).tbz2'
...

and the interactive bug reporter kicks in. That means that some code paths might need to be found and fixed.