### PR TITLE
Equo zsh completion updates

### DIFF
--- a/client/equo-completion.zsh
+++ b/client/equo-completion.zsh
@@ -6,7 +6,7 @@ typeset -A opt_args
 
 _equo_get_mirrors()
 {
-  cmds=( ${(f)"$(equo $1 --help | grep -P '^  (?!(-h|<package>))' | sed -r 's/^  (-*\w+)(, -\w|)  +(\w.*)/\1:\3/')"} )
+  mirrors=( ${(f)"$(equo status | grep Repository\ name | cut -d: -f2 | sed 's/^\ *//')"} )
   _describe -t packages 'mirrors' mirrors
 }
 

--- a/client/equo-completion.zsh
+++ b/client/equo-completion.zsh
@@ -31,8 +31,7 @@ _equo_get_available_packages()
 _arguments -C \
   "--help[print help]" \
   "--version[print version]" \
-  "--nocolor[dont use colors]" \
-  "--color[use colors(default)]" \
+  "--color[force colored output]" \
   "--bashcomp[print bash completion script]"\
   '1:command:->cmds' \
   '*:subcommand:->args'

--- a/client/equo-completion.zsh
+++ b/client/equo-completion.zsh
@@ -6,7 +6,7 @@ typeset -A opt_args
 
 _equo_get_mirrors()
 {
-  mirrors=( ${(f)"$(equo status | grep Repository\ name | cut -d: -f2 | sed 's/^\ *//')"} )
+  cmds=( ${(f)"$(equo $1 --help | grep -P '^  (?!(-h|<package>))' | sed -r 's/^  (-*\w+)(, -\w|)  +(\w.*)/\1:\3/')"} )
   _describe -t packages 'mirrors' mirrors
 }
 
@@ -38,7 +38,7 @@ _arguments -C \
 
 case $state in
   cmds)
-    cmds=( ${(f)"$(equo --help |tr "\t" ":" | grep "^:[^:-]" | sed 's/^:\(\w*\).*:\+/\1:/')"} )
+    cmds=( ${(f)"$(equo --help | grep -P '^  (?!(-h|--color|available))' | sed -r 's/^  (\w+)( \[.*\]|)  +(\w.*)/\1:\3/')"} )
     _describe -t commands 'equo command' cmds
   ;;
   args)

--- a/client/equo-completion.zsh
+++ b/client/equo-completion.zsh
@@ -18,7 +18,7 @@ _equo_get_cmds()
 
 _equo_get_installed_packages()
 {
-  packages=( ${(f)"$(equo query list installed | equo query list installed | sed 's/.*\///')"}  )
+  packages=( ${(f)"$(equo query list installed | sed 's/.*\///')"}  )
   _describe -t packages 'installed packages' packages
 }
 

--- a/client/equo-completion.zsh
+++ b/client/equo-completion.zsh
@@ -12,7 +12,7 @@ _equo_get_mirrors()
 
 _equo_get_cmds()
 {
-  cmds=( ${(f)"$(equo $1 --help | tr "\t" ":" | grep "^:[^:]" | sed 's/^:\([^:\ ]*\)[^:]*:*/\1:/')"} )
+  cmds=( ${(f)"$(equo $1 --help | sed 's/--multifetch/--multifetch  can be/' | sed -r -e '/^(positional|action:)/ {N; d;}' | grep -P '^  (?!-h|<package>|{|   )' | sed -r 's/^ {2,4}(-*[a-zA-z0-9-]+)(, -\w|)  +(\w.*)/\1:\3/')"} )
   _describe -t commands 'command params' cmds
 }
 

--- a/client/equo-completion.zsh
+++ b/client/equo-completion.zsh
@@ -12,7 +12,11 @@ _equo_get_mirrors()
 
 _equo_get_cmds()
 {
-  cmds=( ${(f)"$(equo $1 --help | sed 's/--multifetch/--multifetch  can be/' | sed -r -e '/^(positional|action:)/ {N; d;}' | grep -P '^  (?!-h|<package>|{|   )' | sed -r 's/^ {2,4}(-*[a-zA-z0-9-]+)(, -\w|)  +(\w.*)/\1:\3/')"} )
+  cmds=( ${(f)"$(equo $1 --help |
+    sed 's/--multifetch/--multifetch  can be/' |
+    sed -r -e '/^(positional|action:)/ {N; d;}' |
+    grep -P '^  (?!-h|<package>|{|   )' |
+    sed -r 's/^ {2,4}(-*[a-zA-z0-9-]+)(, -\w|)  +(\w.*)/\1:\3/')"} )
   _describe -t commands 'command params' cmds
 }
 
@@ -38,7 +42,9 @@ _arguments -C \
 
 case $state in
   cmds)
-    cmds=( ${(f)"$(equo --help | grep -P '^  (?!(-h|--color|available))' | sed -r 's/^  (\w+)( \[.*\]|)  +(\w.*)/\1:\3/')"} )
+    cmds=( ${(f)"$(equo --help |
+      grep -P '^  (?!(-h|--color|available))' |
+      sed -r 's/^  (\w+)( \[.*\]|)  +(\w.*)/\1:\3/')"} )
     _describe -t commands 'equo command' cmds
   ;;
   args)

--- a/client/equo-completion.zsh
+++ b/client/equo-completion.zsh
@@ -47,7 +47,7 @@ case $state in
         _equo_get_cmds $line[1] && return 0
         _equo_get_installed_packages
       ;;
-      install|fetch|search|source|mask|unmask)
+      install|i|fetch|download|search|s|source|src|mask|unmask)
         _equo_get_cmds $line[1] && return 0
         _equo_get_available_packages $line[-1]
       ;;
@@ -63,7 +63,7 @@ case $state in
           ;;
         esac
       ;;
-      query)
+      query|q)
         case $line[2] in
           changelog|revdeps|files|needed|removal|graph|revgraph)
             _equo_get_installed_packages
@@ -91,7 +91,7 @@ case $state in
       notice)
         _equo_get_mirrors
       ;;
-      cleanup|status)
+      cleanup|status|st|--info|hop)
       ;;
       *)
         _equo_get_cmds $line[1]


### PR DESCRIPTION
Updates to the zsh completion script. The main issue is that the `equo -h` output has changed drastically since the last time this was touched. There are other small updates i.e., `--nocolor` is not a thing any more, and the desc for `--color` is slightly different.

Note that I am using `grep -P` for the help parsing. This can easily be reduced to a `grep -E` statement, but since this is for Sabayon specifically, there is no reason not to use `grep -P`.