### PR TITLE
Fix issue on use basic authentication with python3.4:

### DIFF
--- a/lib/entropy/fetchers.py
+++ b/lib/entropy/fetchers.py
@@ -596,8 +596,9 @@ class UrlFetcher(TextInterface):
 
             # Handle HTTP Basic auth
             if self.__http_basic_user and self.__http_basic_pwd:
-                basic_header = base64.encodestring('%s:%s' % (
-                    self.__http_basic_user, self.__http_basic_pwd)).replace('\n', '')
+                basic_header = base64.b64encode(('%s:%s' % (
+                    self.__http_basic_user, self.__http_basic_pwd)
+                ).encode('utf-8')).decode('utf-8')
 
                 headers = {
                     'User-Agent': user_agent,


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib64/python3.4/base64.py", line 519, in _input_type_check
    m = memoryview(s)
TypeError: memoryview: str object does not have the buffer interface

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/bin/equo", line 15, in <module>
    main()
  File "/usr/lib/entropy/client/solo/main.py", line 332, in main
    exit_st = func(*func_args)
  File "/usr/lib/entropy/client/solo/commands/command.py", line 406, in _call_exclusive
    return func(client)
  File "/usr/lib/entropy/client/solo/commands/update.py", line 115, in _update
    rc = self._normal_update(entropy_client)
  File "/usr/lib/entropy/client/solo/commands/update.py", line 236, in _normal_update
    rc = repo_intf.sync()
  File "/usr/lib/entropy/lib/entropy/client/interfaces/repository.py", line 327, in sync
    rc = self._run_sync()
  File "/usr/lib/entropy/lib/entropy/client/interfaces/repository.py", line 146, in _run_sync
    self._entropy, repo, self.force, self._gpg_feature)
  File "/usr/lib/entropy/lib/entropy/client/interfaces/db.py", line 2764, in update
    return updater.update()
  File "/usr/lib/entropy/lib/entropy/client/interfaces/db.py", line 2029, in update
    selected = self._select_database_mirror()
  File "/usr/lib/entropy/lib/entropy/client/interfaces/db.py", line 428, in _select_database_mirror
    https_validate_cert = https_validate_cert)
  File "/usr/lib/entropy/lib/entropy/client/interfaces/db.py", line 1992, in _remote_revision
    fetch_rc = fetcher.download()
  File "/usr/lib/entropy/lib/entropy/fetchers.py", line 391, in download
    status = downloader()
  File "/usr/lib/entropy/lib/entropy/fetchers.py", line 600, in _urllib_download
    self.__http_basic_user, self.__http_basic_pwd)).replace('\n', '')
  File "/usr/lib64/python3.4/base64.py", line 548, in encodestring
    return encodebytes(s)
  File "/usr/lib64/python3.4/base64.py", line 536, in encodebytes
    _input_type_check(s)
  File "/usr/lib64/python3.4/base64.py", line 522, in _input_type_check
    raise TypeError(msg) from err
TypeError: expected bytes-like object, not str