### PR TITLE
[zsh-completion] Fix help message parse bugs and add improvements

### DIFF
--- a/client/equo-completion.zsh
+++ b/client/equo-completion.zsh
@@ -12,11 +12,22 @@ _equo_get_mirrors()
 
 _equo_get_cmds()
 {
-  cmds=( ${(f)"$(equo $1 --help |
-    sed 's/--multifetch/--multifetch  can be/' |
-    sed -r -e '/^(positional|action:)/ {N; d;}' |
+  # If we return the equo --help text and have a 1st argument
+  # then that means there is no matching name so return nothing
+  local help_txt=$(equo $@ --help)
+  if [[ "$1" && ${help_txt[0,16]} == 'usage: equo [-h]' ]]; then
+    cmds=( )
+  # Otherwise, parse it
+  else
+    cmds=(
+    ${(f)"$(
+    printf "%s" "$help_txt" |
+    sed -e 's/--multifetch/--multifetch  can be/' \
+    -r -e '/^(positional|action:)/ {N; d;}' |
     grep -P '^  (?!-h|<package>|{|   )' |
-    sed -r 's/^ {2,4}(-*[a-zA-z0-9-]+)(, -\w|)  +(\w.*)/\1:\3/')"} )
+    sed -r 's/^ {2,4}(-*\w+)(, *-\w+)? +(\w.*)/\1:\3/')"}
+    )
+  fi
   _describe -t commands 'command params' cmds
 }
 

--- a/client/equo-completion.zsh
+++ b/client/equo-completion.zsh
@@ -93,8 +93,7 @@ case $state in
               installed)
               ;;
               *)
-                cmds=( ${(f)"$(equo query list --help |tr "\t" ":" | grep "^::[^:]" | sed 's/^::\([^:\ ]*\)[^:]*:*/\1:/')"} )
-                _describe -t commands 'command params' cmds
+                _equo_get_cmds $line
               ;;
             esac
           ;;


### PR DESCRIPTION
This fixes a bug where certain tab completions would be met with lots of
sed errors.
It is also faster since it uses 1 less sed process.

Additionally it will also show 'no matches' if there are no matches found
for a command completion, instead of showing a suggestion to add 1st level
commands on.

Before: equo X (no cmds left to add) zsh suggests install, query, remove
etc.

Now it will properly say there are not more suggestions for most of the $1
terms

Also fix completion for equo query list

Before no completions would show. Now we remove unneeded code and use the
same completion processing for other commands.