### PR TITLE
[entropy.core] fix entropy tag sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ misc/po/*.mo
 server/doc/man/*.1
 #*#
 lib/*test*.py
+.idea
+venv

--- a/lib/entropy/dep.py
+++ b/lib/entropy/dep.py
@@ -644,11 +644,10 @@ def _nat_sort_key(key):
         strings and numbers parsed as number with the empty string as
         first and last element.
     """
-    def convert(text):
-        return int(text) if text.isdigit() else text.lower()
     if key is None:
         key = ''
-    return [convert(c) for c in re.split(digits_group, key.strip())]
+    return [int(c) if c.isdigit() else c.lower()
+            for c in re.split(digits_group, key.strip())]
 
 def entropy_compare_package_tags(tag_a, tag_b):
     """

--- a/lib/tests/dep.py
+++ b/lib/tests/dep.py
@@ -115,22 +115,54 @@ class DepTest(unittest.TestCase):
         ver_a = ("1.0.0", "1.0.0", 0,)
         ver_b = ("1.0.1", "1.0.0", 0.10000000000000001,)
         ver_c = ("1.0.0", "1.0.1", -0.10000000000000001,)
+        ver_d = ("4.9.44", "4.11.12", -2,)
 
         self.assertEqual(et.compare_versions(ver_a[0], ver_a[1]), ver_a[2])
         self.assertEqual(et.compare_versions(ver_b[0], ver_b[1]), ver_b[2])
         self.assertEqual(et.compare_versions(ver_c[0], ver_c[1]), ver_c[2])
+        self.assertEqual(et.compare_versions(ver_d[0], ver_d[1]), ver_d[2])
 
     def test_get_newer_version(self):
-        vers = ["1.0", "3.4", "0.5", "999", "9999", "10.0"]
-        out_vers = ['9999', '999', '10.0', '3.4', '1.0', '0.5']
+        vers = ["1.0", "3.4", "0.5", "999", "9999", "10.0", "10.11.12", "10.1.32", "10.9.44"]
+        out_vers = ['9999', '999', '10.11.12', '10.9.44', '10.1.32', '10.0', '3.4', '1.0', '0.5']
         self.assertEqual(et.get_newer_version(vers), out_vers)
+
+    def test_compare_tag_versions(self):
+        tag_ver_a = ("4.11.0-sabayon", "4.11.0-sabayon", 0,)
+        tag_ver_b = ("4.4.0-sabayon", "4.9.0-sabayon", -1,)
+        tag_ver_c = ("4.11.0-sabayon", "4.1.0-sabayon", 1,)
+        tag_ver_d = ("4.9.44", "3.11.12", 1,)
+        tag_ver_e = ("2.11.59", "4.12.0", -1,)
+        tag_ver_f = ("2222", "2223", -1,)
+
+        self.assertEqual(et.entropy_compare_package_tags(tag_ver_a[0], tag_ver_a[1]), tag_ver_a[2])
+        self.assertEqual(et.entropy_compare_package_tags(tag_ver_b[0], tag_ver_b[1]), tag_ver_b[2])
+        self.assertEqual(et.entropy_compare_package_tags(tag_ver_c[0], tag_ver_c[1]), tag_ver_c[2])
+        self.assertEqual(et.entropy_compare_package_tags(tag_ver_d[0], tag_ver_d[1]), tag_ver_d[2])
+        self.assertEqual(et.entropy_compare_package_tags(tag_ver_e[0], tag_ver_e[1]), tag_ver_e[2])
+        self.assertEqual(et.entropy_compare_package_tags(tag_ver_f[0], tag_ver_f[1]), tag_ver_f[2])
 
     def test_get_entropy_newer_version(self):
         vers = [("1.0", "2222", 1,), ("3.4", "2222", 0,), ("1.0", "2223", 1,),
             ("1.0", "2223", 3,)]
         out_vers = [('1.0', '2223', 3), ('1.0', '2223', 1),
             ('3.4', '2222', 0), ('1.0', '2222', 1)]
+        vers2 = [("340.102", "3.18.0-sabayon", 1,),
+                 ("340.102", "4.11.0-sabayon", 5,),
+                 ("340.102", "4.1.0-sabayon", 3,),
+                 ("381.09", "4.11.0-sabayon", 0,),
+                 ("381.09", "4.11.0-sabayon", 8,),
+                 ("381.09", "3.18.0-sabayon", 0,),
+                 ("381.09", "4.1.0-sabayon", 0,),]
+        out_vers2 = [("381.09", "4.11.0-sabayon", 8,),
+                     ("381.09", "4.11.0-sabayon", 0,),
+                     ("340.102", "4.11.0-sabayon", 5,),
+                     ("381.09", "4.1.0-sabayon", 0,),
+                     ("340.102", "4.1.0-sabayon", 3,),
+                     ("381.09", "3.18.0-sabayon", 0,),
+                     ("340.102", "3.18.0-sabayon", 1,),]
         self.assertEqual(et.get_entropy_newer_version(vers), out_vers)
+        self.assertEqual(et.get_entropy_newer_version(vers2), out_vers2)
 
     def test_create_package_filename(self):
         package_category = "app-foo"


### PR DESCRIPTION
This PR will introduce the natural sorting for entropy tags instead of the standard python sorting.
This fix is needed because we have some issues selecting the newest version like for nvidia-drivers.
Indeed the current behaviour in entropy now is that the tag 4.9.0-sabayon is an higher version if compared with 4.11.0-sabayon.
