### PR TITLE
Fix rescue generate

### DIFF
--- a/client/solo/commands/rescue.py
+++ b/client/solo/commands/rescue.py
@@ -434,8 +434,15 @@ Tools to rescue the running system.
         # open a repository at the old path, if repo_path is
         # not in place, Entropy will forward us to the in-RAM
         # database (for sqlite), which is not what we want.
-        inst_repo.initializeRepository()
-        inst_repo.commit()
+        gen_repo = entropy_client.open_generic_repository(
+            repo_path, dbname=InstalledPackagesRepository.NAME,
+            xcache=False, skip_checks=True)
+        gen_repo.initializeRepository()
+        gen_repo.commit()
+        gen_repo.close()
+
+        entropy_client.reopen_installed_repository()
+        inst_repo = entropy_client.installed_repository()
 
         entropy_client.output(
             purple(_("Repository initialized, generating metadata")),
@@ -516,6 +523,7 @@ Tools to rescue the running system.
                 revision = data['revision'])
             inst_repo.storeInstalledPackage(package_id,
                 etpConst['spmdbid'])
+            inst_repo.commit()
 
         try:
             os.remove(tmp_path)
@@ -527,7 +535,6 @@ Tools to rescue the running system.
             header=darkgreen(" @@ "), back=True
             )
         inst_repo.createAllIndexes()
-        inst_repo.commit()
         entropy_client.output(
             purple(_("Repository metadata generation complete")),
             header=darkgreen(" @@ ")

--- a/client/solo/commands/rescue.py
+++ b/client/solo/commands/rescue.py
@@ -10,6 +10,7 @@
 
 """
 import os
+import os.path
 import errno
 import sys
 import argparse
@@ -443,6 +444,11 @@ Tools to rescue the running system.
 
         entropy_client.reopen_installed_repository()
         inst_repo = entropy_client.installed_repository()
+
+        # Sanity check: make sure we're not accidentally using the in-RAM db
+        if not os.path.exists(repo_path):
+            print("Repository creation failed")
+            return 1
 
         entropy_client.output(
             purple(_("Repository initialized, generating metadata")),

--- a/client/solo/commands/rescue.py
+++ b/client/solo/commands/rescue.py
@@ -447,7 +447,11 @@ Tools to rescue the running system.
 
         # Sanity check: make sure we're not accidentally using the in-RAM db
         if not os.path.exists(repo_path):
-            print("Repository creation failed")
+            entropy_client.output(
+                darkred(_("Repository creation failed")),
+                level="error",
+                importance=1,
+                header=darkred(" @@ "))
             return 1
 
         entropy_client.output(


### PR DESCRIPTION
This PR fixes a bug where `equo rescue generate` would appear to work, but would write the results to the in-memory database instead of the file. (Note that this bug only manifests if there is no pre-existing database.) I've also added a sanity check to make it more obvious if this regresses in the future.