### PR TITLE
[solo.commands.rescue] use world file to replicate by-user status

### DIFF
--- a/client/solo/commands/rescue.py
+++ b/client/solo/commands/rescue.py
@@ -778,7 +778,7 @@ Tools to rescue the running system.
                     entropy.tools.print_traceback()
                     entropy_client.output(
                         "%s, %s: %s" % (
-                            teal(spm_package),
+                            teal(_spm_package),
                             purple(_("Metadata generation error")),
                             err,
                             ),

--- a/lib/entropy/spm/plugins/interfaces/portage_plugin/__init__.py
+++ b/lib/entropy/spm/plugins/interfaces/portage_plugin/__init__.py
@@ -1937,6 +1937,29 @@ class PortagePlugin(SpmPlugin):
 
         return list(filter(catfilter, packages))
 
+    def get_user_selected_packages(self, root = None):
+        """
+        Reimplemented from SpmPlugin class.
+        """
+        world_atoms = set()
+
+        with self._PortageWorldSetLocker(self, root = root):
+            world_file = self.get_user_installed_packages_file(root = root)
+            enc = etpConst['conf_encoding']
+
+            try:
+                with codecs.open(world_file, "r", encoding=enc) \
+                        as world_f:
+                    world_atoms |= set((x.strip() for x in \
+                        world_f.readlines() if x.strip()))
+            except (OSError, IOError) as err:
+                if err.errno != errno.ENOENT:
+                    raise self.Error(err)
+            except UnicodeDecodeError as err:
+                raise self.Error("Portage world file is malformed")
+
+        return frozenset(world_atoms)
+
     def get_package_sets(self, builtin_sets):
         """
         Reimplemented from SpmPlugin class.

--- a/lib/entropy/spm/plugins/interfaces/portage_plugin/__init__.py
+++ b/lib/entropy/spm/plugins/interfaces/portage_plugin/__init__.py
@@ -3288,52 +3288,19 @@ class PortagePlugin(SpmPlugin):
             # new slot format for kernel tagged packages
             myslot = entropy.dep.remove_tag_from_slot(myslot)
 
-        keyslot = key + ":" + myslot
-        key = const_convert_to_rawstring(key)
-        world_file = self.get_user_installed_packages_file()
-        world_dir = os.path.dirname(world_file)
-        world_atoms = set()
-        enc = etpConst['conf_encoding']
-
-        try:
-
-            with self._PortageWorldSetLocker(self, root = root):
-
-                try:
-                    with codecs.open(world_file, "r", encoding=enc) \
-                            as world_f:
-                        world_atoms |= set((x.strip() for x in \
-                            world_f.readlines() if x.strip()))
-                except (OSError, IOError) as err:
-                    if err.errno != errno.ENOENT:
-                        raise
-
-                if keyslot not in world_atoms and \
-                    entropy.tools.istextfile(world_file):
-
-                    world_atoms.discard(key)
-                    world_atoms.add(keyslot)
-                    world_file_tmp = world_file+".entropy_inst"
-
-                    newline = const_convert_to_unicode("\n")
-                    with codecs.open(world_file_tmp, "w", encoding=enc) \
-                            as world_f:
-                        for item in sorted(world_atoms):
-                            world_f.write(item + newline)
-
-                    os.rename(world_file_tmp, world_file)
-
-        except (UnicodeDecodeError, UnicodeEncodeError,) as e:
-
-            mytxt = "%s: %s" % (
-                brown(_("Cannot update SPM installed pkgs file")), world_file,
-            )
-            self.__output.output(
-                red("QA: ") + mytxt + ": " + repr(e),
-                importance = 1,
-                level = "warning",
-                header = darkred("   ## ")
-            )
+        with self._PortageWorldSetLocker(self, root = root):
+            try:
+                self.__add_update_world_file(key, myslot)
+            except (UnicodeDecodeError, UnicodeEncodeError) as e:
+                mytxt = "%s: %s" % (
+                    brown(_("Cannot update SPM installed pkgs file")), world_file,
+                )
+                self.__output.output(
+                    red("QA: ") + mytxt + ": " + repr(e),
+                    importance = 1,
+                    level = "warning",
+                    header = darkred("   ## ")
+                )
 
         return counter
 
@@ -3466,6 +3433,38 @@ class PortagePlugin(SpmPlugin):
                 raise
         else:
             # this must complete successfully
+            os.rename(world_file_tmp, world_file)
+
+    def __add_update_world_file(self, key, slot):
+        keyslot = key + ":" + slot
+        key = const_convert_to_rawstring(key)
+        world_file = self.get_user_installed_packages_file()
+        world_dir = os.path.dirname(world_file)
+        world_atoms = set()
+        enc = etpConst['conf_encoding']
+
+        try:
+            with codecs.open(world_file, "r", encoding=enc) \
+                    as world_f:
+                world_atoms |= set((x.strip() for x in \
+                    world_f.readlines() if x.strip()))
+        except (OSError, IOError) as err:
+            if err.errno != errno.ENOENT:
+                raise
+
+        if keyslot not in world_atoms and \
+            entropy.tools.istextfile(world_file):
+
+            world_atoms.discard(key)
+            world_atoms.add(keyslot)
+            world_file_tmp = world_file+".entropy_inst"
+
+            newline = const_convert_to_unicode("\n")
+            with codecs.open(world_file_tmp, "w", encoding=enc) \
+                    as world_f:
+                for item in sorted(world_atoms):
+                    world_f.write(item + newline)
+
             os.rename(world_file_tmp, world_file)
 
     @staticmethod

--- a/lib/entropy/spm/plugins/skel.py
+++ b/lib/entropy/spm/plugins/skel.py
@@ -589,6 +589,22 @@ class SpmPlugin(Singleton):
         """
         raise NotImplementedError()
 
+    def get_user_selected_packages(self, root = None):
+        """
+        Return installed list of packages that were selected by user as
+        selected (wanted).
+        Packages returned by this function can have a different representation
+        from what e.g. I{get_installed_packages()} returns, that is, no
+        package matching is done for performance.
+
+        @keyword root: specify an alternative root directory "/"
+        @type root: string
+        @return: list of installed packages found
+        @rtype: frozenset
+        @raise entropy.exceptions.SPMError: when something went bad
+        """
+        raise NotImplementedError()
+
     def get_package_sets(self, builtin_sets):
         """
         Package sets are groups of packages meant to ease user installation and


### PR DESCRIPTION
This way 'equo unused' will be even more useful. This could also be used to reduce size of distributed images, assuming correct status of dep/by user of packages.