### PR TITLE
add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: required
+
+services:
+  - docker
+
+before_install:
+- docker pull sabayon/base-amd64
+
+script:
+- >
+    docker run -v $TRAVIS_BUILD_DIR:/entropy sabayon/base-amd64
+    bash -c "equo i dev-util/bsdiff; cd /entropy/lib/tests && LC_ALL=en_US.UTF-8 USERNAME=root ETP_TESTS_NONINTERACTIVE=1 ./run"
+
+notifications:
+  irc: "chat.freenode.net#sabayon-infra"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# [![Build Status](https://travis-ci.org/Sabayon/entropy.svg?branch=master)](https://travis-ci.org/Sabayon/entropy) Sabayon overlay
+
 # Entropy
 
 Entropy is the binary package management of Sabayon Linux.

--- a/lib/tests/security.py
+++ b/lib/tests/security.py
@@ -86,6 +86,8 @@ class SecurityTest(unittest.TestCase):
         self.assertEqual(s_rc, 0)
         self.assertEqual(self._system.available(), True)
 
+    # Asks for the passphrase.
+    @unittest.skipIf(os.getenv("ETP_TESTS_NONINTERACTIVE"), "ETP_TESTS_NONINTERACTIVE is set")
     def test_gpg_handling(self):
 
         # available keys should be empty


### PR DESCRIPTION
USERNAME is needed in lib/entropy/security.py.
Added support for ETP_TESTS_NONINTERACTIVE (and skipped one test).