### PR TITLE
Fix handling IUSE with default options with Python 3

### DIFF
--- a/lib/entropy/spm/plugins/interfaces/portage_plugin/__init__.py
+++ b/lib/entropy/spm/plugins/interfaces/portage_plugin/__init__.py
@@ -4052,8 +4052,8 @@ class PortagePlugin(SpmPlugin):
     def _resolve_useflags(self, iuse_list, use_list, use_force):
         use = set()
         disabled_use = set()
-        plus = const_convert_to_rawstring("+")
-        minus = const_convert_to_rawstring("-")
+        plus = const_convert_to_unicode("+")
+        minus = const_convert_to_unicode("-")
         for myiuse in iuse_list:
             if myiuse[0] in (plus, minus,):
                 myiuse = myiuse[1:]


### PR DESCRIPTION
On ARM environment injection of packages doesn't handle
correctly IUSE with default options (+)/(-) and this
doesn't expose correctly the USE flags of the package for dependencies
test.

Example:
```
  ╠  @@ Searching...
  ╠      @@ Package: app-arch/xz-utils-5.2.4-r2 branch: 5, [__system__]
  ╠          Category:        app-arch
  ╠          Name:            xz-utils
  ╠          Masked:          False
  ╠          Installed:       version: 5.2.4-r2 ~ tag: NoTag ~ revision:
  9999
  ╠          Slot:            0
  ╠          Size:            29.3kB
  ╠          Download:
  packages/armv7l/5/app-arch/app-arch:xz-utils-5.2.4-r2.efbac860e08851659458db1e4b55a03c3f3711e0.tbz2
  ╠          Checksum:        0
  ╠          SHA1:            efbac860e08851659458db1e4b55a03c3f3711e0
  ╠          SHA256:
  69989fb2f120539938b060531ba17e8cc2e2e3ed879ef937aacc5f2b9abcfc70
  ╠          GPG:             No
  ╠          ## Dependencies:
  ╠          ##               [3] >=app-portage/elt-patches-20170815
  ╠          ##               Legend:
  ╠          ##               {0} Runtime dependency
  ╠          ##               {1} Post dependency
  ╠          ##               {2} Manually added (by staff) dependency
  ╠          ##               {3} Build dependency
  ╠          ## Conflicts:
  ╠          ##               <app-arch/lzma-4.63
  ╠          ##               <app-arch/p7zip-4.57
  ╠          ##               app-arch/lzma-utils
  ╠          Homepage:        https://tukaani.org/xz/
  ╠          Description:     utils for managing LZMA compressed
  ╠                           files
  ╠          USE flags:       -+extra-filters -+threads -abi_mips_n32
  ╠                           -abi_mips_n64 -abi_mips_o32
  ╠                           -abi_ppc_32 -abi_ppc_64 -abi_s390_32
  ╠                           -abi_s390_64 -abi_x86_32 -abi_x86_64
  ╠                           -abi_x86_x32 -elibc_FreeBSD
  ╠                           -static-libs arm armv5te armv6
  ╠                           armv6t2 big-endian cpu_flags_arm_edsp
  ╠                           cpu_flags_arm_thumb cpu_flags_arm_thumb2
  ╠                           cpu_flags_arm_v4 cpu_flags_arm_v5
  ╠                           cpu_flags_arm_v6 cpu_flags_arm_v7
  ╠                           cpu_flags_arm_vfp elibc_glibc
  ╠                           kernel_linux nls userland_GNU
```
USE flags extra-filters and threads MUST in the format:
```
╠          USE flags:       -abi_mips_n32 -abi_mips_n64
╠                           -abi_mips_o32 -abi_ppc_32 -abi_ppc_64
╠                           -abi_s390_32 -abi_s390_64 -abi_x86_32
╠                           -abi_x86_64 -abi_x86_x32 -elibc_FreeBSD
╠                           -static-libs arm armv5te armv6
╠                           armv6t2 big-endian cpu_flags_arm_edsp
╠                           cpu_flags_arm_thumb cpu_flags_arm_thumb2
╠                           cpu_flags_arm_v4 cpu_flags_arm_v5
╠                           cpu_flags_arm_v6 cpu_flags_arm_v7
╠                           cpu_flags_arm_vfp elibc_glibc
╠                           extra-filters kernel_linux nls
╠                           threads userland_GNU
```